### PR TITLE
Change PR number fetch + fix octokit usage

### DIFF
--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
 
 const prNum = github.context.payload.pull_request.number;
 
-const octokit = new github.GitHub(token);
+const octokit = github.getOctokit(token);
 
 octokit.pulls.update({
   owner: repoOwner,

--- a/main.js
+++ b/main.js
@@ -13,15 +13,13 @@ const body = core.getInput('body', {
 
 const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
 
-const fs = require('fs');
-const ev = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8'));
-const prNum = ev.pull_request.number;
+const prNum = github.context.payload.pull_request.number;
 
 const octokit = new github.GitHub(token);
 
 octokit.pulls.update({
   owner: repoOwner,
   repo: repoName,
-  body: JSON.parse(body),
+  body: body,
   pull_number: prNum,
 });


### PR DESCRIPTION
- Fixed the usage of `octokit` after dependabot update.
- Get PR from payload in the event context instead of reading the file.